### PR TITLE
Update MobileNetworkTypeTile.java

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/quicksettings/MobileNetworkTypeTile.java
+++ b/packages/SystemUI/src/com/android/systemui/quicksettings/MobileNetworkTypeTile.java
@@ -57,6 +57,7 @@ public class MobileNetworkTypeTile extends QuickSettingsTile implements NetworkS
 
                 Intent intent = new Intent(ACTION_MODIFY_NETWORK_MODE);
                 switch (mMode) {
+                    case Phone.NT_MODE_LTE_GSM_WCDMA:/*since 10.2(jira:2098), add case NT_MODE_LTE_GSM_WCDMA*/
                     case Phone.NT_MODE_WCDMA_PREF:
                     case Phone.NT_MODE_GSM_UMTS:
                         intent.putExtra(EXTRA_NETWORK_MODE, Phone.NT_MODE_GSM_ONLY);
@@ -71,7 +72,7 @@ public class MobileNetworkTypeTile extends QuickSettingsTile implements NetworkS
                         } else {
                             intent.putExtra(EXTRA_NETWORK_MODE, Phone.NT_MODE_WCDMA_PREF);
                             mInternalState = STATE_TURNING_ON;
-                            mIntendedMode = Phone.NT_MODE_WCDMA_PREF;
+                            mIntendedMode = Phone.NT_MODE_LTE_GSM_WCDMA;
                         }
                         break;
                     case Phone.NT_MODE_GSM_ONLY:
@@ -82,7 +83,7 @@ public class MobileNetworkTypeTile extends QuickSettingsTile implements NetworkS
                         } else {
                             intent.putExtra(EXTRA_NETWORK_MODE, Phone.NT_MODE_WCDMA_PREF);
                             mInternalState = STATE_TURNING_ON;
-                            mIntendedMode = Phone.NT_MODE_WCDMA_PREF;
+                            mIntendedMode = Phone.NT_MODE_LTE_GSM_WCDMA;/*since 10.2(jira:2098), change NT_MODE_WCDMA_PREF->NT_MODE_LTE_GSM_WCDMA*/
                         }
                         break;
                 }
@@ -192,6 +193,7 @@ public class MobileNetworkTypeTile extends QuickSettingsTile implements NetworkS
             case Phone.NT_MODE_WCDMA_PREF:
             case Phone.NT_MODE_WCDMA_ONLY:
             case Phone.NT_MODE_GSM_UMTS:
+            case Phone.NT_MODE_LTE_GSM_WCDMA:/*since 10.2, 2098*/
                 return STATE_2G_AND_3G;
             case Phone.NT_MODE_GSM_ONLY:
                 return STATE_2G_ONLY;


### PR DESCRIPTION
jira:2098
2g 3g toggle not working for CM10.2. A fix has been merged in settings when "2g only" checkbox wasn't working. The same change needs to be replicated for this SystemUI tile. It's basically because of the "no-longer-supported" constant "NT_MODE_WCDMA_PREF". Migration to "NT_MODE_LTE_GSM_WCDMA" is suggested.
