### PR TITLE
Fix a boot problem when usage-history.xml is empty.

### DIFF
--- a/services/java/com/android/server/am/UsageStatsService.java
+++ b/services/java/com/android/server/am/UsageStatsService.java
@@ -366,7 +366,7 @@ public final class UsageStatsService extends IUsageStats.Stub {
             XmlPullParser parser = Xml.newPullParser();
             parser.setInput(fis, null);
             int eventType = parser.getEventType();
-            while (eventType != XmlPullParser.START_TAG) {
+            while (eventType != XmlPullParser.START_TAG && eventType != XmlPullParser.END_DOCUMENT) {
                 eventType = parser.next();
             }
             String tagName = parser.getName();


### PR DESCRIPTION
This often occurs after an incomplete reboot or shutdown.
Such as a battery pull when writing /data/system/usagestats/usage-history.xml.
