### PR TITLE
Update PermissionDialog.java

### DIFF
--- a/services/java/com/android/server/PermissionDialog.java
+++ b/services/java/com/android/server/PermissionDialog.java
@@ -135,6 +135,7 @@ class PermissionDialog extends BasePermissionDialog {
             }
             mService.notifyOperation(mCode, mUid, mPackageName, mode,
                 remember);
+            mHandler.removeMessages(ACTION_IGNORED_TIMEOUT);
             dismiss();
         }
     };


### PR DESCRIPTION
Remove the time_out operation while we have chose the correct options.
This commit will avoid the situation that when we already chosen the allow or deny but also notify operation when the handler receive the time out message.
