### PR TITLE
Themes: Expose elevation attribute of notification_header_bg for themers

### DIFF
--- a/packages/SystemUI/res/layout/status_bar_expanded_header.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded_header.xml
@@ -26,7 +26,7 @@
     android:paddingStart="@dimen/notification_side_padding"
     android:paddingEnd="@dimen/notification_side_padding"
     android:baselineAligned="false"
-    android:elevation="4dp"
+    android:elevation="@dimen/notification_header_elevation"
     android:background="@drawable/notification_header_bg"
     android:clickable="true"
     android:focusable="true"

--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -143,6 +143,9 @@
     <dimen name="standard_notification_panel_width">416dp</dimen><!-- includes notification_side_padding on each side -->
     <dimen name="notification_panel_width">@dimen/match_parent</dimen>
 
+    <!-- Notification header elevation -->
+    <dimen name="notification_header_elevation">4dp</dimen>
+    
     <!-- Gravity for the notification panel -->
     <integer name="standard_notification_panel_layout_gravity">0x31</integer><!-- top|center_horizontal -->
     <integer name="notification_panel_layout_gravity">0x37</integer><!-- fill_horizontal|top -->


### PR DESCRIPTION
This commit essentially helps themers to make flat expanded status bar i.e. QuickSettings view, doing so by exposing the hardcoded elevation level of header background from layout to @dimen/notification_header_elevation.
