### PR TITLE
Support Google Webview by default

### DIFF
--- a/core/java/android/webkit/WebViewFactory.java
+++ b/core/java/android/webkit/WebViewFactory.java
@@ -75,8 +75,17 @@ public final class WebViewFactory {
     private static PackageInfo sPackageInfo;
 
     public static String getWebViewPackageName() {
-        return AppGlobals.getInitialApplication().getString(
-                com.android.internal.R.string.config_webViewPackageName);
+        String configres = AppGlobals.getInitialApplication().getString(
+                     com.android.internal.R.string.config_webViewPackageName);
+         Application initialApplication = AppGlobals.getInitialApplication();
+         try {
+              Context webViewContext = initialApplication.createPackageContext(configres,
+                         Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY);
+            if (isPackageInstalled(webViewContext, configres)){ return configres; }
+             else { return "com.android.webview"; }
+         } catch (PackageManager.NameNotFoundException e){
+             return "com.android.webview";
+         }
     }
 
     public static PackageInfo getLoadedPackageInfo() {
@@ -393,6 +402,14 @@ public final class WebViewFactory {
             }
         } catch (PackageManager.NameNotFoundException e) {
             Log.e(LOGTAG, "Failed to list WebView package libraries for loadNativeLibrary", e);
+        }
+    }
+    
+    private static boolean isPackageInstalled(Context context, String packageName) {
+        try {
+            return context.getPackageManager().getPackageInfo(packageName, 0) != null;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
if google webview (com.google.android.webview) available, use it. 
If its not, fallback to the AOSP one (com.android.webview)
