### PR TITLE
Change the width of the extra wide wifi icon

### DIFF
--- a/packages/SystemUI/res/drawable/stat_sys_wifi_signal_2.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_wifi_signal_2.xml
@@ -14,7 +14,7 @@ Copyright (C) 2014 The Android Open Source Project
     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="20dp"
+        android:width="17.8dp"
         android:height="17dp"
         android:viewportWidth="26.0"
         android:viewportHeight="24.0">


### PR DESCRIPTION
Reduce the width of the extra-wide WiFi icon on the status bar to the android default.
