### PR TITLE
GLES: Fix parsing error of ro.kernel.qemu prop

### DIFF
--- a/core/jni/android_view_GLES20Canvas.cpp
+++ b/core/jni/android_view_GLES20Canvas.cpp
@@ -966,7 +966,7 @@ static void android_view_GLES20Canvas_flushLayerUpdates(JNIEnv* env, jobject cla
 static jboolean android_view_GLES20Canvas_isAvailable(JNIEnv* env, jobject clazz) {
 #ifdef USE_OPENGL_RENDERER
     char prop[PROPERTY_VALUE_MAX];
-    if (property_get("ro.kernel.qemu", prop, NULL) == 0) {
+    if (property_get("ro.kernel.qemu", prop, NULL) == 0 || atoi(prop) == 0) {
         // not in the emulator
         return JNI_TRUE;
     }


### PR DESCRIPTION
Some board set ro.kernel.qemu to 0 and the old code failed to handle it.

Change-Id: I6d3cbaf485d338be75bfc66fd48c9d28aa9cd398
