### PR TITLE
National roaming for O2 Germany and former E-Plus

### DIFF
--- a/core/res/res/values-mcc262-mnc07/config.xml
+++ b/core/res/res/values-mcc262-mnc07/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- O2 Germany and former E-Plus are merging their networks, consider non roaming -->
+    <string-array translatable="false" name="config_operatorConsideredNonRoaming">
+        <item>26203</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
In Germany provider O2 and E-Plus are merging their networks. In a first step they do this by national roaming. This prevents CM users to use the former E-Plus network for mobile data without activating the roaming option.
