### PR TITLE
Update QuickSettings ADB-USB Icon

### DIFF
--- a/packages/SystemUI/res/drawable/ic_dynamic_qs_adb.xml
+++ b/packages/SystemUI/res/drawable/ic_dynamic_qs_adb.xml
@@ -1,58 +1,39 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (C) 2015 The CyanogenMod Project
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-         http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
+ Copyright (c) 2015 The CyanogenMod Project
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48">
-
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    
     <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M 37.727707,9.975208 L 40.285946,3.7258741 C 40.541238,3.1009409
-40.243401,2.3882503 39.618464,2.1329586 38.993529,1.8776669 38.28084,2.1755027
-38.025548,2.8004407 L 35.374234,9.275815 C 32.449014,8.605674 28.718028,8.350381
-24.258396,8.350381 l 0,0.01596 0,0 0,-0.01862 c -0.582384,0 -1.148814,0.0053
--1.707266,0.01596 l -0.0027,0 c -3.712371,0.06116 -6.863631,0.329751
--9.405913,0.912136 L 10.491243,2.8004407 C 10.235951,2.1755075
-9.5232609,1.8776669 8.8983273,2.1329586 8.2733938,2.3882503 7.9755532,3.1009409
-8.2308452,3.7258741 L 10.789084,9.975208 c -3.3959157,1.284439
--5.1989153,3.45708 -5.1989153,6.94607 l 0,7.31837 0,1.898735 0,2.084884 c
-0,6.411552 6.0738233,8.379428 16.9583033,8.557599 l 0,0.01064 0.67546,0 c
-0.340389,0.0027 0.686097,0.0053 1.034464,0.0053 l 0,-0.0053 0,0 0,0.0053 c
-0.348368,0 0.694075,-0.0027 1.034465,-0.0053 l 0.04786,0 c 11.280713,-0.11169
-17.585893,-2.031699 17.585893,-8.565578 l 0,-2.087543 0,-1.898735 0,-7.31837 C
-42.929314,13.429631 41.123615,11.259649 37.7277,9.975211 Z M 14.661013,27.973293
-c -3.084777,0 -5.5845131,-2.499733 -5.5845131,-5.584512 0,-3.084778
-2.4997361,-5.584511 5.5845131,-5.584511 3.084778,0 5.584512,2.499733
-5.584512,5.584511 0,3.084779 -2.499734,5.584512 -5.584512,5.584512 z m
-10.185086,4.050102 -1.178065,0 c -0.86693,0 -1.571642,-0.702054
--1.571642,-1.571642 0,-0.03192 0.008,-0.06382 0.01064,-0.09573 l 4.300073,0 c
-0.0027,0.03192 0.01064,0.06116 0.01064,0.09573 0,0.869588 -0.704712,1.571642
--1.571641,1.571642 z m 9.00968,-4.050102 c -3.084778,0 -5.584512,-2.499733
--5.584512,-5.584512 0,-3.084778 2.499734,-5.584511 5.584512,-5.584511 3.084777,0
-5.584512,2.499733 5.584512,5.584511 -0.0027,3.084779 -2.502394,5.584512
--5.584512,5.584512 z" />
+    android:fillColor="#FFFFFF"
+    android:pathData="M21.3,6.6L21,6.9c0,1-3.8,1.7-9,1.7S3,7.9,3,6.9L2.7,6.6C2.1,7.6,2,10.7,2,12.5
+    c0,1.8,0.1,4.9,0.7,5.8l0,0C3.2,19.3,7.2,20,12,20c4.8,0,8.8-0.7,9.3-1.7l0,0c0.6-1,0.7-4.1,0.7-5.8C22,10.7,21.9,7.6,21.3,6.6z
+    M7,17c-1.7,0-3-1.3-3-3s1.3-3,3-3c1.7,0,3,1.3,3,3S8.7,17,7,17z
+    M17,17c-1.7,0-3-1.3-3-3c0-1.7,1.3-3,3-3c1.7,0,3,1.3,3,3 C20,15.7,18.7,17,17,17z" />
     <path
-        android:fillColor="#FFFFFF"
-        android:strokeWidth="16"
-        android:strokeLineJoin="round"
-        android:strokeLineCap="round"
-        android:pathData="M 23.2448199 33.152538 L 24.8907709 33.152538 Q 25.9999988 33.152538
-25.9999988 34.2617659 L 25.9999988 44.6534791 Q 25.9999988 45.762707 24.8907709 45.762707
-L 23.2448199 45.762707 Q 22.135592 45.762707 22.135592 44.6534791 L 22.135592 34.2617659
-Q 22.135592 33.152538 23.2448199 33.152538 Z" />
+    android:fillColor="#BBFFFFFF"
+    android:pathData="M21.4,6.9c0,1-4.2,1.9-9.4,1.9S2.6,7.9,2.6,6.9S6.8,5,12,5S21.4,5.8,21.4,6.9z" />
+    <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M19.7,6.5c-0.1,0.3-0.5,0.5-0.8,0.3c-0.3-0.1-0.5-0.5-0.3-0.8l1.3-3.1c0.1-0.3,0.5-0.5,0.8-0.3
+    C20.9,2.7,21.1,3,21,3.4L19.7,6.5z" />
+    <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M4.3,6.5C4.5,6.8,4.8,7,5.1,6.8C5.5,6.7,5.6,6.3,5.5,6L4.2,2.9C4.1,2.6,3.7,2.4,3.4,2.5
+    C3.1,2.7,2.9,3,3,3.4L4.3,6.5z" />
 </vector>


### PR DESCRIPTION
Update ADB-USB icon in Quick Settings from Lollipop to Marshmallow.
